### PR TITLE
Format everything with rustfmt

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,19 @@
 mod renderer;
 mod screen;
 
-use crossterm::{event::*, Result, terminal::size, QueueableCommand};
 use crate::screen::{Screen, SimpleTerminalWindow};
 use crossterm::cursor::{DisableBlinking, EnableBlinking};
-use std::io::{Write, stdout, Read};
-use std::process::{exit, Command};
-use crossterm::terminal::{enable_raw_mode, disable_raw_mode};
-use std::ops::Deref;
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+use crossterm::{event::*, terminal::size, QueueableCommand, Result};
 use std::borrow::Borrow;
 use std::cell::RefCell;
+use std::io::{stdout, Read, Write};
+use std::ops::Deref;
+use std::process::Stdio;
+use std::process::{exit, Command};
 use std::rc::Rc;
 use std::thread::sleep;
 use std::time::Duration;
-use std::process::Stdio;
 
 fn main() {
     let mut stdout = std::io::stdout();
@@ -21,9 +21,12 @@ fn main() {
 
     enable_raw_mode();
     stdout
-        .queue(DisableBlinking).unwrap()
-        .queue(EnableMouseCapture).unwrap()
-        .flush().unwrap();
+        .queue(DisableBlinking)
+        .unwrap()
+        .queue(EnableMouseCapture)
+        .unwrap()
+        .flush()
+        .unwrap();
 
     screen.add_container(Rc::new(RefCell::new(Box::new(SimpleTerminalWindow::new(
         5,
@@ -76,19 +79,39 @@ fn main() {
                         match mouseEvent {
                             MouseEvent::Down(mouse_button, x, y, key_modifiers) => {
                                 screen.check_top_container(x, y);
-                                screen.get_top_container().unwrap().borrow_mut().on_mouse_down(x, y);
+                                screen
+                                    .get_top_container()
+                                    .unwrap()
+                                    .borrow_mut()
+                                    .on_mouse_down(x, y);
                             }
                             MouseEvent::Up(mouse_button, x, y, key_modifiers) => {
-                                screen.get_top_container().unwrap().borrow_mut().on_mouse_up(x, y);
+                                screen
+                                    .get_top_container()
+                                    .unwrap()
+                                    .borrow_mut()
+                                    .on_mouse_up(x, y);
                             }
                             MouseEvent::Drag(mouse_button, x, y, key_modifiers) => {
-                                screen.get_top_container().unwrap().borrow_mut().on_mouse_drag(x, y);
+                                screen
+                                    .get_top_container()
+                                    .unwrap()
+                                    .borrow_mut()
+                                    .on_mouse_drag(x, y);
                             }
                             MouseEvent::ScrollUp(x, y, key_modifiers) => {
-                                screen.get_top_container().unwrap().borrow_mut().on_scroll_y(-1);
+                                screen
+                                    .get_top_container()
+                                    .unwrap()
+                                    .borrow_mut()
+                                    .on_scroll_y(-1);
                             }
                             MouseEvent::ScrollDown(x, y, key_modifiers) => {
-                                screen.get_top_container().unwrap().borrow_mut().on_scroll_y(1);
+                                screen
+                                    .get_top_container()
+                                    .unwrap()
+                                    .borrow_mut()
+                                    .on_scroll_y(1);
                             }
                             _ => {}
                         };
@@ -97,13 +120,19 @@ fn main() {
                         if key_event.code == KeyCode::Char('c') {
                             if key_event.modifiers == KeyModifiers::CONTROL {
                                 stdout
-                                    .queue(EnableBlinking).unwrap()
-                                    .queue(DisableMouseCapture).unwrap();
+                                    .queue(EnableBlinking)
+                                    .unwrap()
+                                    .queue(DisableMouseCapture)
+                                    .unwrap();
                                 disable_raw_mode().unwrap();
                             }
                         }
 
-                        screen.get_top_container().unwrap().borrow_mut().on_key(key_event.code, key_event.modifiers);
+                        screen
+                            .get_top_container()
+                            .unwrap()
+                            .borrow_mut()
+                            .on_key(key_event.code, key_event.modifiers);
                     }
                     _ => {}
                 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1,25 +1,32 @@
-use std::io::{stdout, Write, BufWriter, Stdout, StdoutLock};
-use crossterm::{
-    ExecutableCommand, QueueableCommand,
-    terminal, cursor, style::{self, Colorize}, Result
-};
 use crate::screen::Screen;
-use std::ops::Deref;
+use crossterm::{
+    cursor,
+    style::{self, Colorize},
+    terminal, ExecutableCommand, QueueableCommand, Result,
+};
 use std::cmp::min;
 use std::ffi::CString;
+use std::io::{stdout, BufWriter, Stdout, StdoutLock, Write};
+use std::ops::Deref;
 
 fn draw_rect(stdout: &mut Vec<u8>, x: u16, y: u16, w: u16, h: u16, max_w: u16, max_h: u16) {
-    for x_iterator in x..(x+w) {
-        for y_iterator in y..(y+h) {
-            if (x_iterator < max_w && y_iterator < max_h) && ((x_iterator == x || y_iterator == y) || (x_iterator == x + w - 1 || y_iterator == y + h - 1)) {
+    for x_iterator in x..(x + w) {
+        for y_iterator in y..(y + h) {
+            if (x_iterator < max_w && y_iterator < max_h)
+                && ((x_iterator == x || y_iterator == y)
+                    || (x_iterator == x + w - 1 || y_iterator == y + h - 1))
+            {
                 stdout
-                    .queue(cursor::MoveTo(x_iterator,y_iterator)).unwrap()
-                    .queue(style::PrintStyledContent( "█".white())).unwrap();
-            }
-            else {
+                    .queue(cursor::MoveTo(x_iterator, y_iterator))
+                    .unwrap()
+                    .queue(style::PrintStyledContent("█".white()))
+                    .unwrap();
+            } else {
                 stdout
-                    .queue(cursor::MoveTo(x_iterator,y_iterator)).unwrap()
-                    .queue(style::PrintStyledContent( "█".black())).unwrap();
+                    .queue(cursor::MoveTo(x_iterator, y_iterator))
+                    .unwrap()
+                    .queue(style::PrintStyledContent("█".black()))
+                    .unwrap();
             }
         }
     }
@@ -35,8 +42,10 @@ fn render_text(stdout: &mut Vec<u8>, x: u16, y: u16, max_h: u16, text: String) {
         let line_str = line.to_string();
 
         stdout
-            .queue(cursor::MoveTo(x, y + i)).unwrap()
-            .queue(crossterm::style::Print(line_str.as_str())).unwrap();
+            .queue(cursor::MoveTo(x, y + i))
+            .unwrap()
+            .queue(crossterm::style::Print(line_str.as_str()))
+            .unwrap();
 
         i += 1;
     }
@@ -53,7 +62,15 @@ pub fn redraw(stdout: &mut Stdout, w: u16, h: u16, screen: &Screen) -> Result<()
     for con in screen.containers.iter() {
         let con = con.deref().borrow();
         // Draw the container border around the window
-        draw_rect(&mut stdout, con.get_x() - 1, con.get_y() - 1, con.get_width() + 2, con.get_height() + 2, w, h);
+        draw_rect(
+            &mut stdout,
+            con.get_x() - 1,
+            con.get_y() - 1,
+            con.get_width() + 2,
+            con.get_height() + 2,
+            w,
+            h,
+        );
         // Draw the container title info
         let mut info = "".to_string();
         let title = con.get_title();
@@ -61,17 +78,23 @@ pub fn redraw(stdout: &mut Stdout, w: u16, h: u16, screen: &Screen) -> Result<()
             info.push_str(title.unwrap());
             info.push(' ');
         }
-        info.push_str(format!("W: {} H: {} X: {} Y: {} Cursor: {:?} {}",
-                              con.get_width(),
-                              con.get_height(),
-                              con.get_x(),
-                              con.get_y(),
-                              con.get_cursor(),
-                              con.get_printed_chars()
-        ).as_str());
+        info.push_str(
+            format!(
+                "W: {} H: {} X: {} Y: {} Cursor: {:?} {}",
+                con.get_width(),
+                con.get_height(),
+                con.get_x(),
+                con.get_y(),
+                con.get_cursor(),
+                con.get_printed_chars()
+            )
+            .as_str(),
+        );
         stdout
-            .queue(cursor::MoveTo(con.get_x(), con.get_y() - 1)).unwrap()
-            .queue(crossterm::style::Print(info)).unwrap();
+            .queue(cursor::MoveTo(con.get_x(), con.get_y() - 1))
+            .unwrap()
+            .queue(crossterm::style::Print(info))
+            .unwrap();
         // Draw the container's content
         let mut con_width = con.get_width();
         let mut con_height = con.get_height();
@@ -86,17 +109,31 @@ pub fn redraw(stdout: &mut Stdout, w: u16, h: u16, screen: &Screen) -> Result<()
             if con.get_y() + con_height > h {
                 con_height -= con.get_y() + con_height - h;
             }
-            render_text(&mut stdout, con.get_x(), con.get_y(), con_height - 1, con.get_content());
+            render_text(
+                &mut stdout,
+                con.get_x(),
+                con.get_y(),
+                con_height - 1,
+                con.get_content(),
+            );
         }
         // Draw the resize handles
         if con.get_x() + con.get_width() < w {
             stdout
-                .queue(cursor::MoveTo(con.get_x() + con.get_width(), con.get_y() + con.get_height() / 2)).unwrap()
+                .queue(cursor::MoveTo(
+                    con.get_x() + con.get_width(),
+                    con.get_y() + con.get_height() / 2,
+                ))
+                .unwrap()
                 .queue(crossterm::style::Print("↔"))?;
         }
         if con.get_y() + con.get_height() < h {
             stdout
-                .queue(cursor::MoveTo(con.get_x() + con.get_width() / 2, con.get_y() + con.get_height())).unwrap()
+                .queue(cursor::MoveTo(
+                    con.get_x() + con.get_width() / 2,
+                    con.get_y() + con.get_height(),
+                ))
+                .unwrap()
                 .queue(crossterm::style::Print("↕"))?;
         }
     }
@@ -104,7 +141,8 @@ pub fn redraw(stdout: &mut Stdout, w: u16, h: u16, screen: &Screen) -> Result<()
     // Render some info about TermUI
     let info_string = format!("Stdout buffer size : {}", stdout.len());
     stdout
-        .queue(cursor::MoveTo(2, 0)).unwrap()
+        .queue(cursor::MoveTo(2, 0))
+        .unwrap()
         .queue(crossterm::style::Print(info_string));
     // Render dev console
     s.write_all(&stdout);


### PR DESCRIPTION
rustfmt is included with [`rustup`‘s `default` profile](https://github.com/rust-lang/rustup#profiles). It is very prevalent throughout the Rust community, and makes reading code easier for everyone by keeping style consistent. I formatted the entire project by running `cargo fmt`.

Feel free not to merge, though, as this is a pretty huge diff.